### PR TITLE
fix: prevent Stack smashing protect failure when more than 5 touch points are returned.

### DIFF
--- a/src/bb_captouch.cpp
+++ b/src/bb_captouch.cpp
@@ -577,7 +577,7 @@ int i, j, rc;
            return 0;
        }
        i = ucTemp[0]; // number of touch points available
-       if (i >= 1) { // get data
+       if (i >= 1 && i <= 5) { // get data
            rc = I2CReadRegister(_iAddr, TOUCH_REG_XH, ucTemp, 6*i); // read X+Y position(s)
            if ((ucTemp[0] & 0x40) == 0 && (ucTemp[2] & 0xf0) != 0xf0) { // finger is down
                pTI->x[0] = ((ucTemp[0] & 0xf) << 8) | ucTemp[1];


### PR DESCRIPTION
if more than 5 touch points are returned it will write beyond the array bounds of `ucTemp[32]`:

```
Stack smashing protect failure!

Backtrace: 0x40377e26:0x3fcb6420 0x403817b1:0x3fcb6440 0x4037746e:0x3fcb6460 0x4200785e:0x3fcb6480 0x4205a836:0x3fcb64e0 0x42032bb2:0xffffffff |<-CORRUPTED

0x40377e26: panic_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/panic.c:408
0x403817b1: esp_system_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/esp_system.c:137
0x4037746e: __stack_chk_fail at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/stack_check.c:35
0x42007842: BBCapTouch::getSamples(_fttouchinfo*) at PlatformIO/Projects/meshtastic-latest/.pio/libdeps/seeed-sensecap-indicator-tft/bb_captouch/src/bb_captouch.cpp:572
0x4205a83d: LGFX_Touch::getTouchXY(unsigned short*, unsigned short*) at PlatformIO/Projects/device-ui/include/graphics/LGFX/LGFX_INDICATOR.h:46
```